### PR TITLE
Remove Okteto

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,7 @@ List of free Trials/Credit for Managed Kubernetes Services
   - Description: $250 credit for a month period from the account creation to use Civo kubernetes and services.
   - Requirements: a Credit Card is required for signing up, but you will not be charged if your credit runs out.
   - Link: [https://www.civo.com/signup](https://www.civo.com/signup)
-- **Okteto Cloud**
-  - Description: Managed Kubernetes service designed for developers. Free developer accounts come with 8GB of RAM, 4 CPUs and 5GB Disk space. The apps sleep after 24 hours of inactivity. You have access to a single namespace. 
-  - Details: [https://okteto.com/docs/cloud](https://okteto.com/docs/cloud)
-  - Requirements: a Github account is required for signing up.
-  - Link: [https://cloud.okteto.com/](https://cloud.okteto.com/)
- - **Huawei Cloud**
+- **Huawei Cloud**
    - Description:  Register and get 1500 hours of free trial. Up to 10Gb available to download and store docker container images (Always free)
    - Details: [https://activity.huaweicloud.com/intl/en-us/free_packages/](https://activity.huaweicloud.com/intl/en-us/free_packages/)
    - Requirements: A Credit Card is required for signing up


### PR DESCRIPTION
On January 15, 2024, Okteto discontinued the free SaaS tier for individual accounts. This means that access to Okteto Cloud is no longer available.

Source: https://www.okteto.com/okteto-cloud-2024/